### PR TITLE
argcomplete

### DIFF
--- a/pydesignflow/shortcut.py
+++ b/pydesignflow/shortcut.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: 2024 Tobias Kaiser <mail@tb-kaiser.de>
 # SPDX-License-Identifier: Apache-2.0
 
+# PYTHON_ARGCOMPLETE_OK
+
 import importlib.util
 from pathlib import Path
 import sys

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,9 @@ setuptools.setup(
     install_requires=[
         "tabulate >= 0.8.0",
     ],
+    extras_require={
+        'argcomplete': ['argcomplete>=3.6.2'],
+    },
     entry_points={
         "console_scripts": [
             "flow = pydesignflow.shortcut:main"


### PR DESCRIPTION
# Major Addition
- added *argcomplete* tab-completion support as an **optional** extension
  - installable using `pip install pydesignflow[argcomplete]`
- both `flow <block> <task>` and `flow <block>.<task>` commands are supported.
  - by default, only *SPACE*-notation is suggested to keep the suggestions clean
  - But dot-notation will be suggested once a Dot is placed after a valid block. e.g. `flow <block>.[TAB]`
  - Furthermore, *Options* starting with '--' or '-' will only be suggested once a '-' is tab completed in the terminal. e.g. `flow ... -[TAB]`
- This resolves Issue #2.

# Argcomplete installation requirements
See: https://pypi.org/project/argcomplete/
1. `pip install pydesignflow[argcomplete]`
2. `activate-global-python-argcomplete`
3. `eval "$(register-python-argcomplete flow)"`